### PR TITLE
Adding per-file editable and lock icons in tabs

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -156,9 +156,11 @@ export default (model, actions) =>
         const content = file.content || model.linkPatched[file.url] || ''
             , mode = modes[file.name.split('.').pop()] || 'javascript'
 
+        const editable = (model.state.editable === false || file.editable === false) ? false : true
+
         cm.setOption('lineWrapping', mode.lineWrapping || false)
 
-        cm.setOption('readOnly', (file.editable === undefined) ? false : !file.editable)
+        cm.setOption('readOnly', !editable)
 
         if (!doc) {
           doc = CodeMirror.Doc(content, mode)

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -156,8 +156,8 @@ export default (model, actions) =>
         const content = file.content || model.linkPatched[file.url] || ''
             , mode = modes[file.name.split('.').pop()] || 'javascript'
 
-        const editable = (model.state.editable === false || file.editable === false) ? false : true
-
+        const editable = model.state.editable && file.editable !== false
+        
         cm.setOption('lineWrapping', mode.lineWrapping || false)
 
         cm.setOption('readOnly', !editable)

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -158,6 +158,8 @@ export default (model, actions) =>
 
         cm.setOption('lineWrapping', mode.lineWrapping || false)
 
+        cm.setOption('readOnly', (file.editable === undefined) ? false : !file.editable)
+
         if (!doc) {
           doc = CodeMirror.Doc(content, mode)
 

--- a/src/editor/tabs.js
+++ b/src/editor/tabs.js
@@ -32,7 +32,7 @@ function linkTabs(model, actions) {
         target: '_blank',
         onclick: e => model.linkContent[link.url] && e.preventDefault()
       }, link.name),
-      m.trust(link.editable === false ? ' 🔒' : '')],
+      link.editable === false ? ' 🔒' : ''],
       () => model.linkContent[link.url] && actions.select(link.url),
       link === model.selectedFile(),
       model

--- a/src/editor/tabs.js
+++ b/src/editor/tabs.js
@@ -27,11 +27,12 @@ export default (model, actions) =>
 function linkTabs(model, actions) {
   return model.state.links.map(link =>
     tab(
-      m('a' + b.c('inherit'), {
+      [m('a' + b.c('inherit'), {
         href: link.url,
         target: '_blank',
         onclick: e => model.linkContent[link.url] && e.preventDefault()
       }, link.name),
+      m.trust(link.editable === false ? ' 🔒' : '')],
       () => model.linkContent[link.url] && actions.select(link.url),
       link === model.selectedFile(),
       model
@@ -42,7 +43,7 @@ function linkTabs(model, actions) {
 function fileTabs(model, actions) {
   return model.state.files.map(file =>
     tab(
-      file.name,
+      file.name + (file.editable === false ? ' 🔒' : ''),
       () => actions.select(file.name),
       file === model.selectedFile(),
       model


### PR DESCRIPTION
This adds an editable option for each item in the files and links arrays.
It also adds a lock icon in tabs that are read only.

My first pull request, so I hope I did everything correctly. 😄 