### PR TITLE
Fix .set() bugs

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -69,8 +69,7 @@ export default function(model) {
 
     getLinks()
 
-    if (model.selected() !== state.selected)
-      model.selected(state.selected)
+    model.selected(state.selected || model.selected())
 
     refresh()
     m.redraw()


### PR DESCRIPTION
This fixes two bugs.
1. On .set() the current tab is deselected if you haven't defined "selected" in the new state.
2. When setting "editable" in .set(), the changes doesn't take effect until a new tab is selected.