### PR TITLE
Fix lock icon when file/link.editable is undefined

### DIFF
--- a/src/editor/tabs.js
+++ b/src/editor/tabs.js
@@ -36,7 +36,7 @@ function linkTabs(model, actions) {
           target: '_blank',
           onclick: e => model.linkContent[link.url] && e.preventDefault()
         }, link.name),
-        !link.editable && icon({ size: 16, class: b.ml(6).class }, lockIcon)
+        link.editable === false && icon({ size: 16, class: b.ml(6).class }, lockIcon)
       ),
       () => model.linkContent[link.url] && actions.select(link.url),
       link === model.selectedFile(),
@@ -50,7 +50,7 @@ function fileTabs(model, actions) {
     tab(
       m('div' + b.d('flex'),
         file.name,
-        !file.editable && icon({ size: 16, class: b.ml(6).class }, lockIcon)
+        file.editable === false && icon({ size: 16, class: b.ml(6).class }, lockIcon)
       ),
       () => actions.select(file.name),
       file === model.selectedFile(),


### PR DESCRIPTION
!file.editable returns true even when editable isn't set, since "undefined" is falsy. Made all my files show up as locked. :D 