### PR TITLE
use endsWith util instead of String.endsWith

### DIFF
--- a/src/srcdoc/index.js
+++ b/src/srcdoc/index.js
@@ -290,7 +290,7 @@ function loadRemoteScript(script) {
 }
 
 function moduleCheck(script) {
-  script.module = script.name.endsWith('.mjs') || isModuleRegex.test(script.content)
+  script.module = endsWith('.mjs', script.name) || isModuleRegex.test(script.content)
   return script
 }
 


### PR DESCRIPTION
Noticed this error when I opened flems.io in IE 11, not sure if it's still supported but since the rest of the code uses the `endsWith` util I figured it was just a mistake.