### PR TITLE
Add `downlevelIteration: true` to TSC's compilerOptions

### DIFF
--- a/src/compilers.js
+++ b/src/compilers.js
@@ -44,9 +44,10 @@ const compilers = {
     const result = window.ts.transpileModule(file.content, {
       fileName: file.name,
       compilerOptions: {
+        downlevelIteration: true,
+        jsx: 'react',
         module: 'ESNext',
-        sourceMap: true,
-        jsx: 'react'
+        sourceMap: true
       }
     })
 


### PR DESCRIPTION
This solves misc issues where TS doesn't follow the iteration protocol by default, like in `[... new Set]`, or in `for ... of` loops.

E.g. : https://flems.io/#0=N4IgzgpgNhDGAuEAmIBcIB08wgDQgDMBLGHVAbVADsBDAWwjUwCsd9YB7KxbpgBwAUAHRCsRuAATkMMqhADuEgMoR4AgJQBddXnDQ48IlzIgADKgBMAZhABfXNXqN0WNiE7cIvdIJHZxUjIYcooqalo67Bx0fCQQAE5M2LqQMAhGVCbmpgC05tZ2mrZAA

The option is detailed [here](https://www.typescriptlang.org/tsconfig#downlevelIteration).
A similar problem has been solved with this [here](https://github.com/vercel/next.js/issues/17094).

The [importHelpers](https://www.typescriptlang.org/tsconfig#importHelpers) option may also be handy, but I'm not sure it would mesh well with Flems as is (note that the "importHelpers" example in the "downlevelIteration" section of the docs is wrong).