### PR TITLE
Have TSC target ESNext rather than the ES3 default

### DIFF
--- a/src/compilers.js
+++ b/src/compilers.js
@@ -44,7 +44,8 @@ const compilers = {
     const result = window.ts.transpileModule(file.content, {
       fileName: file.name,
       compilerOptions: {
-        module: 'ESNext',
+        module: 'esnext',
+        target: 'esnext',
         sourceMap: true,
         jsx: 'react'
       }


### PR DESCRIPTION
This should solve [this problem](https://flems.io/#0=N4IgzgpgNhDGAuEAmIBcIB08wgDQgDMBLGHVAbVADsBDAWwjUwCsd9YB7KxbpgBwAUAHRCsRuAATkMMqhADuEgMoR4AgJQBddXnDQ48IlzIgADKgBMAZhABfXNXqN0WNiE7cIvdIJHZxUjIYcooqalo67Bx0fCQQAE5M2LqQMAhGVCbmpgC05tZ2mrZAA) where spreading a set into an array gives an error, and result in snappier code than the compatbility shims that are added when TSC compiles down to ES3.

Not sure about the case of the options. The TS docs has it all in lowercase, you were using "module: ESNext"...