### PR TITLE
Fix extraneous properties in state clean

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -95,8 +95,9 @@ export const createFlemsIoLink = state => {
 }
 
 function clean(state) {
-  const clean = Object.keys(defaults()).reduce((acc, x) =>
-    (x in state && state[x] !== defaults[x] && (acc[x] = state[x]), acc)
+  const d = defaults()
+  const clean = Object.keys(d).reduce((acc, x) =>
+    (x in state && state[x] !== d[x] && (acc[x] = state[x]), acc)
   , {})
 
   if (state.files && state.files.length)


### PR DESCRIPTION
## Context

Introduced in https://github.com/porsager/flems/commit/c626602275c3f3a0f104a2bc4dc199c96ac58779#diff-11b7451007049bfefb31193b5a9af9bbd494cae1b851425587076d31a0e8b516R56-R94

`defaults` is a function that returns a state object. `defaults[x]` is accessing the property on the function, which is undefined for most properties, the effect of which means extra properties are present even though they match the defaults.

## Testing

### Before

<img width="610" height="349" alt="Screenshot 2026-05-16 at 11 55 27 PM" src="https://github.com/user-attachments/assets/88217de3-b969-4149-b655-0a911513d1b1" />


### After

<img width="563" height="144" alt="Screenshot 2026-05-16 at 11 54 56 PM" src="https://github.com/user-attachments/assets/33e764cd-48cf-46d9-b10c-a806333b80f3" />

